### PR TITLE
Bugfix: Copy dotfiles when packages are adopted

### DIFF
--- a/Classes/Command/PackageCommandController.php
+++ b/Classes/Command/PackageCommandController.php
@@ -65,7 +65,7 @@ class PackageCommandController extends CommandController
         // copy package
         $sourcePackagePath = realpath($sourcePackage->getPackagePath());
         $targetPackagePath = realpath($packagesPath) . DIRECTORY_SEPARATOR . $target;
-        Files::copyDirectoryRecursively($sourcePackagePath, $targetPackagePath);
+        Files::copyDirectoryRecursively($sourcePackagePath, $targetPackagePath, false, true);
 
         $sourcePackageDescription = new PackageKey($source);
         $targetPackagedescription = new PackageKey($target);


### PR DESCRIPTION
Without this chantalle would skip over dotfiles when packages are adopted which. This is bad since this skips things like .gitignore or .eslintrc and other important files.