### PR TITLE
keep original composer vendor if unchanged

### DIFF
--- a/Classes/Command/PackageCommandController.php
+++ b/Classes/Command/PackageCommandController.php
@@ -75,6 +75,6 @@ class PackageCommandController extends CommandController
         $this->outputLine(sprintf('Package %s was adopted as %s in path %s', $source, $target, $targetPackagePath));
         $this->outputLine();
         $this->outputLine(sprintf('Please run `composer require %s && composer remove %s` to finalize this.', $targetPackageDescription->getComposerName(), $sourcePackageDescription->getComposerName()));
-        $this->outputLine(sprintf('Also consider to remove CreativeResort.Chantalle with `composer remove sitegeist/chantalle`'));
+        $this->outputLine(sprintf('Also consider to remove Sitegeist.Chantalle with `composer remove sitegeist/chantalle`'));
     }
 }

--- a/Classes/Command/PackageCommandController.php
+++ b/Classes/Command/PackageCommandController.php
@@ -75,6 +75,6 @@ class PackageCommandController extends CommandController
         $this->outputLine(sprintf('Package %s was adopted as %s in path %s', $source, $target, $targetPackagePath));
         $this->outputLine();
         $this->outputLine(sprintf('Please run `composer require %s && composer remove %s` to finalize this.', $targetPackageDescription->getComposerName(), $sourcePackageDescription->getComposerName()));
-        $this->outputLine(sprintf('Also consider to remove CreativeResort.Chantalle with `composer remove creative-resort/chantalle`'));
+        $this->outputLine(sprintf('Also consider to remove CreativeResort.Chantalle with `composer remove sitegeist/chantalle`'));
     }
 }

--- a/Classes/Command/PackageCommandController.php
+++ b/Classes/Command/PackageCommandController.php
@@ -68,13 +68,13 @@ class PackageCommandController extends CommandController
         Files::copyDirectoryRecursively($sourcePackagePath, $targetPackagePath, false, true);
 
         $sourcePackageDescription = new PackageKey($source);
-        $targetPackagedescription = new PackageKey($target);
-        PackageService::alterPackageNamespace($targetPackagePath, $sourcePackageDescription, $targetPackagedescription);
+        $targetPackageDescription = new PackageKey($target);
+        PackageService::alterPackageNamespace($targetPackagePath, $sourcePackageDescription, $targetPackageDescription);
 
         // final message
         $this->outputLine(sprintf('Package %s was adopted as %s in path %s', $source, $target, $targetPackagePath));
         $this->outputLine();
-        $this->outputLine(sprintf('Please run `composer require %s && composer remove %s` to finalize this.', $targetPackagedescription->getComposerName(), $sourcePackageDescription->getComposerName()));
-        $this->outputLine(sprintf('Also consider to remove Sitegeist.Chantalle with `composer remove sitegeist/chantalle`'));
+        $this->outputLine(sprintf('Please run `composer require %s && composer remove %s` to finalize this.', $targetPackageDescription->getComposerName(), $sourcePackageDescription->getComposerName()));
+        $this->outputLine(sprintf('Also consider to remove CreativeResort.Chantalle with `composer remove creative-resort/chantalle`'));
     }
 }

--- a/Classes/Domain/PackageKey.php
+++ b/Classes/Domain/PackageKey.php
@@ -7,7 +7,8 @@ use Neos\ContentRepository\Utility;
 
 class PackageKey
 {
-    protected $packageKey;
+    protected $vendor;
+    protected $name;
 
     /**
      * PackageDescription constructor.
@@ -18,7 +19,7 @@ class PackageKey
      */
     public function __construct(string $packageKey)
     {
-        $this->packageKey = $packageKey;
+        list($this->vendor, $this->name) = explode('.', $packageKey, 2);
     }
 
     /**
@@ -34,7 +35,23 @@ class PackageKey
      */
     public function getPackageKey(): string
     {
-        return $this->packageKey;
+        return $this->vendor . '.' . $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getVendor(): string
+    {
+        return $this->vendor;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
     }
 
     /**
@@ -42,7 +59,14 @@ class PackageKey
      */
     public function getComposerName(): string
     {
-        list($vendor, $name) = explode('.', $this->packageKey, 2);
+        return static::buildComposerName($this->vendor, $this->name);
+    }
+
+    /**
+     * @return string
+     */
+    public static function buildComposerName($vendor, $name): string
+    {
         return strtolower($vendor) . '/' . strtolower(str_replace('.', '-', $name));
     }
 
@@ -51,7 +75,7 @@ class PackageKey
      */
     public function getPhpNamespace(): string
     {
-        return str_replace('.', '\\', $this->packageKey);
+        return str_replace('.', '\\', $this->getPackageKey());
     }
 
     /**
@@ -59,6 +83,6 @@ class PackageKey
      */
     public function getRootNodeName(): string
     {
-        return Utility::renderValidNodeName($this->packageKey);
+        return Utility::renderValidNodeName($this->getPackageKey());
     }
 }

--- a/Classes/Service/ConfigurationAdjustmentService.php
+++ b/Classes/Service/ConfigurationAdjustmentService.php
@@ -12,19 +12,19 @@ class ConfigurationAdjustmentService
      * @param array $replacements key=>value pairs
      * @param $baseDirectory
      */
-    public static function replaceSettingPathes(array $replacements, $baseDirectory)
+    public static function replaceSettingPaths(array $replacements, $baseDirectory)
     {
         $dir      = new \RecursiveDirectoryIterator($baseDirectory . DIRECTORY_SEPARATOR . 'Configuration', \FilesystemIterator::SKIP_DOTS);
         $iterator = new \RecursiveIteratorIterator($dir);
 
-        $replacePathes = [];
+        $replacePaths = [];
         foreach ($replacements as $source => $target) {
-            $replacePathes[] = [
+            $replacePaths[] = [
                 'source' => explode('.', $source),
                 'target' => explode('.', $target)
             ];
         }
-
+        
         /** @var \SplFileInfo $item */
         foreach ($iterator as $item) {
             if (!$item->isFile()) {
@@ -34,7 +34,7 @@ class ConfigurationAdjustmentService
                 $configuration = Yaml::parseFile($item->getRealPath());
                 $configurationWasAltered = false;
 
-                foreach ($replacePathes as $replacement) {
+                foreach ($replacePaths as $replacement) {
                     if (is_array($configuration) && $affectedConfiguration = Arrays::getValueByPath($configuration, $replacement['source'])) {
                         $configuration = Arrays::setValueByPath($configuration, $replacement['target'], $affectedConfiguration);
                         $configuration = Arrays::unsetValueByPath($configuration, $replacement['source']);


### PR DESCRIPTION
When the Flow package vendor is the same for **source** and **target** package, the composer vendor is retained **exactly as it was** in the source package

This allows for example copying of a package `neos-themes/boilerplate` to `neos-themes/portfolio`, without compacting the vendor name to `neosthemes`, which would be missing the dash.